### PR TITLE
fixed http_proxy from configuration not being used

### DIFF
--- a/build-scripts/start_build.py
+++ b/build-scripts/start_build.py
@@ -135,8 +135,9 @@ if __name__ == '__main__':
     print("build_charts: {}".format(build_charts))
     print("push_charts: {}".format(push_charts))
 
-    if configuration["http_proxy"] == "":
-        http_proxy = os.environ.get("http_proxy", "")
+    http_proxy = configuration["http_proxy"]
+    if http_proxy == "":
+        http_proxy = os.environ.get("http_proxy", "")    
 
     if http_proxy == "":
         print("no proxy configured...")


### PR DESCRIPTION
Small fix in the start_build.py script. Currently setting a proxy in the .yaml file has no effect and will actually cause the start_build.py script to fail.