### PR TITLE
do not install the server with uppercase hostname

### DIFF
--- a/server-installation/server_installation.sh
+++ b/server-installation/server_installation.sh
@@ -507,6 +507,10 @@ else
     echo ""
 fi
 
+if [[ ${HOSTNAME}  =~ [A-Z] ]]
+then echo -e "Your hostname ${HOSTNAME} has uppercase letters, which is not compatible with microk8s!"
+    exit
+fi
 
 ### Parsing command line arguments:
 usage="$(basename "$0")


### PR DESCRIPTION
I ran into this problem that the installation failed due to having uppercase hostname. 

The MicroK8s documentation has this to say:
```Ensure the hostname of your machine name does not contain capital letters or underscores. Kubernetes normalizes the machine name causing its registration to fail.
To fix this you can change the hostname or use the --hostname-override argument in kubelet’s configuration in /var/snap/microk8s/current/args/kubelet.```