### PR TITLE
replace "who am i" with "logname"

### DIFF
--- a/server-installation/server_installation.sh
+++ b/server-installation/server_installation.sh
@@ -469,7 +469,7 @@ function install_certs {
 OS_PRESENT=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 OS_PRESENT="${OS_PRESENT%\"}"
 OS_PRESENT="${OS_PRESENT#\"}"
-REAL_USER=$(who am i | awk '{print $1}')
+REAL_USER=$(logname)
 if [ -v SUDO_USER ]; then
     USER_HOME=$(getent passwd $SUDO_USER | cut -d: -f6)
 else


### PR DESCRIPTION
original approach was resulting in blank on ubuntu 20.04

logname appears to be a more reliable approach, see https://www.baeldung.com/linux/identify-user-called-by-sudo