### PR TITLE
Allow a port number in the registry address

### DIFF
--- a/build-scripts/build_helper/build_utils.py
+++ b/build-scripts/build_helper/build_utils.py
@@ -105,8 +105,8 @@ class BuildUtils:
             if "root" in entry.lower():
                 continue
 
-            name = entry.split(":")[1]
-            version = entry.split(":")[2]
+            name = ":".join(entry.split(":")[1:-1])
+            version = entry.split(":")[-1]
             entry_id = f"{name}:{version}"
 
             if "chart:" in entry:

--- a/build-scripts/build_helper/charts_helper.py
+++ b/build-scripts/build_helper/charts_helper.py
@@ -826,10 +826,10 @@ class HelmChart:
 
                             assert (
                                 len(container_tag.split("/")) == 4
-                                and len(container_tag.split(":")) == 2
+                                and len(container_tag.split(":")) in [2, 3]
                             )
                             container_version = container_tag.split(":")[-1]
-                            container_name = container_tag.split(":")[0].split("/")[-1]
+                            container_name = ":".join(container_tag.split(":")[:-1]).split("/")[-1]
                             default_registry = "/".join(container_tag.split("/")[:3])
                             self.add_container_by_tag(
                                 container_registry=default_registry,

--- a/build-scripts/build_helper/container_helper.py
+++ b/build-scripts/build_helper/container_helper.py
@@ -167,7 +167,7 @@ class BaseImage:
             BuildUtils.logger.error("Could not extract base-image!")
             exit(1)
 
-        self.version = tag.split(":")[1]
+        self.version = tag.split(":")[-1]
         self.tag = tag
         self.present = None
 


### PR DESCRIPTION
This PR adds support for private container registries with a port number.

When splitting container tags on ":", the build scripts now take into account the possibility of 3 items getting returned if the registry address includes a port number, in which case the first two components re-joined to form the tag name. The version is always extracted as the last element of the list instead of counting from the head.