### PR TITLE
Check if file exists for apply_file_action in HelperMinio.py

### DIFF
--- a/data-processing/kaapana-plugin/extension/docker/files/plugin/kaapana/operators/HelperMinio.py
+++ b/data-processing/kaapana-plugin/extension/docker/files/plugin/kaapana/operators/HelperMinio.py
@@ -22,6 +22,10 @@ class HelperMinio:
         minioClient, action, bucket_name, object_name, file_path, file_white_tuples=None
     ):
         print(file_path)
+        
+        if not os.path.exists(file_path):
+            raise FileNotFoundError
+            
         if file_white_tuples is not None and not file_path.lower().endswith(
             file_white_tuples
         ):


### PR DESCRIPTION
Check if file exists in apply_action_to_file method. FileNotFoundError is raised when file does not exist.