### PR TITLE
Move kaapana explanation away from the first words

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   </a>
 </p>
 
-Kaapana (from the hawaiian word kaʻāpana, meaning "distributor" or "part") is an open-source toolkit for state-of-the-art platform provisioning in the field of medical data analysis. The applications comprise  AI-based workflows and federated learning scenarios with a focus on radiological and radiotherapeutic imaging. 
+Kaapana is an open-source toolkit for state-of-the-art platform provisioning in the field of medical data analysis. The applications comprise  AI-based workflows and federated learning scenarios with a focus on radiological and radiotherapeutic imaging. The word Kaapana originates from the hawaiian word kaʻāpana, meaning "distributor" or "part".
 
 Obtaining large amounts of medical data necessary for developing and training modern machine learning methods is an extremely challenging effort that often fails in a multi-center setting, e.g. due to technical, organizational and legal hurdles. A federated approach where the data remains under the authority of the individual institutions and is only processed on-site is, in contrast, a promising approach ideally suited to overcome these difficulties.
 


### PR DESCRIPTION
On google or other search engines the first words seen in context with Kaapana is the word explanation which is not the information the usual users wants to know about. 